### PR TITLE
Check for null/"undefined" after modify evaluated in render_data

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -133,14 +133,16 @@ class DataRow {
         // apply passed "modify" configuration setting by using eval()
         // assuming the data is available inside the function as "x"
         this.data = this.raw_data.map((raw, idx) => {
-            if (raw === "undefined" || typeof raw === "undefined" || raw === null) 
-                return ((this.strict) ? null : "n/a");
-
-            // finally, put it all together
             let x = raw;
             let cfg = col_cfgs[idx];
+            let content = (cfg.modify) ? eval(cfg.modify) : x;
+
+            // check for undefined/null values and omit if strict set
+            if (content === "undefined" || typeof content === "undefined" || content === null)
+                return ((this.strict) ? null : "n/a");
+
             return new Object({
-                content: (cfg.modify) ? eval(cfg.modify) : x,
+                content: content,
                 pre: cfg.prefix || "", 
                 suf: cfg.suffix || "",
                 css: cfg.align || "left",


### PR DESCRIPTION
This PR allows modify setting to change a value to null or "undefined" in order to dynamically hide a table row based on a modified column value. My use case is that my MQTT battery sensors report a state of "unknown" rather than "undefined" when no value is available, but flex-table-card checks only for "undefined" when determining whether to exclude a row if strict is set to true. So I need the strict check to be applied after the modify is evaluated.