### PR TITLE
#86 Fix

### DIFF
--- a/docs/example-cfg-data.md
+++ b/docs/example-cfg-data.md
@@ -14,6 +14,9 @@ for the assigned value of `data`:
 * any `key in this.entity` (e.g., `entity_id`, `state`, ...)
 * otherwise a key within `this.entity.attributes` will be assumed 
 
+When accessing attributes, sometimes an attribute object will itself contain objects.
+In that case, you can access the lower object using dotted notation.  eg: object1.object2.field1
+
 If the chosen `data` selector does not resolve to something useful, the
 cell will be marked with an error - collection/rendering should continue w/o any 
 issues. 

--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // VERSION info
-var VERSION = "0.7.3";
+var VERSION = "0.7.1";
 
 // typical [[1,2,3], [6,7,8]] to [[1, 6], [2, 7], [3, 8]] converter
 var transpose = m => m[0].map((x, i) => m.map(x => x[i]));

--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // VERSION info
-var VERSION = "0.7.1";
+var VERSION = "0.7.3";
 
 // typical [[1,2,3], [6,7,8]] to [[1, 6], [2, 7], [3, 8]] converter
 var transpose = m => m[0].map((x, i) => m.map(x => x[i]));
@@ -281,7 +281,28 @@ class DataRow {
                     } else {
                         // no matching data found, complain:
                         //raw_content.push("[[ no match ]]");
-                        raw_content.push(null);
+
+                        let pos = col_key.indexOf('.');
+                        if (pos < 0)
+                        {
+                            raw_content.push(null);
+                        }
+                        else
+                        {
+                            // if the col_key field contains a dotted object (eg: day.monday)
+                            //  then traverse each object to ensure that it exists
+                            //  until the final object value is found.
+                            // if at any point in the traversal, the object is not found
+                            //  then null will be used as the value.
+                            let objs = col_key.split('.');
+                            let value = this.entity.attributes;
+                            if (value) {
+                                for (let idx = 0; value && idx < objs.length; idx++) {
+                                    value = (objs[idx] in value) ? value[objs[idx]] : null;
+                                }
+                            }
+                            raw_content.push(value);
+                        }
                     }
 
                     // @todo: not really nice to clean `raw_content` up here, why


### PR DESCRIPTION
For data selector, allow use of dotted notation.  An example:
`data: object1.field1`
No limit on the number of objects.