### PR TITLE
Fix refresh table only as needed

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -415,6 +415,9 @@ class FlexTableCard extends HTMLElement {
         this.tbl = null;
     }
 
+    // Used to detect changes requiring a table refresh.
+    #old_last_updated = "";
+
     _getRegEx(pats, invert=false) {
         // compile and convert wildcardish-regex to real RegExp
         const real_pats = pats.map((pat) => pat.replace(/\*/g, '.*'));
@@ -561,6 +564,13 @@ class FlexTableCard extends HTMLElement {
 
         // get "data sources / origins" i.e, entities
         let entities = this._getEntities(hass, config.entities, config.entities.include, config.entities.exclude);
+
+        // Check for changes requiring a table refresh.
+        // Return if no changes detected.
+        let last_updated_arr = entities.map(a => a.last_updated);
+        let max = last_updated_arr.sort().slice(-1)[0];
+        if (max == this.#old_last_updated) return;
+        this.#old_last_updated = max;
 
         // `raw_rows` to be filled with data here, due to 'attr_as_list' it is possible to have
         // multiple data `raw_rows` acquired into one cell(.raw_data), so re-iterate all rows


### PR DESCRIPTION
Fix for Issues:

- #53
- #88

Have tested against adding/removing/changing rows, populated by both entities and attributes. Also tested multiple table instances on a page (View).

Config changes are handled by HA prompt:

> Your dashboard was updated. Refresh to see changes?

Rows now only update when source entity changes.

Looked at more "official" patterns in use, but didn't seem a good fit for this model.