### PR TITLE
fix-update-on-entity-delete

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -422,6 +422,7 @@ class FlexTableCard extends HTMLElement {
 
     // Used to detect changes requiring a table refresh.
     #old_last_updated = "";
+    #old_rowcount = 0;
 
     _getRegEx(pats, invert=false) {
         // compile and convert wildcardish-regex to real RegExp
@@ -572,10 +573,14 @@ class FlexTableCard extends HTMLElement {
 
         // Check for changes requiring a table refresh.
         // Return if no changes detected.
-        let last_updated_arr = entities.map(a => a.last_updated);
-        let max = last_updated_arr.sort().slice(-1)[0];
-        if (max == this.#old_last_updated) return;
-        this.#old_last_updated = max;
+        let rowcount = entities.length;
+        if (rowcount == this.#old_rowcount) {
+            let last_updated_arr = entities.map(a => a.last_updated);
+            let max = last_updated_arr.sort().slice(-1)[0];
+            if (max == this.#old_last_updated) return;
+            this.#old_last_updated = max;
+        }
+        this.#old_rowcount = rowcount;
 
         // `raw_rows` to be filled with data here, due to 'attr_as_list' it is possible to have
         // multiple data `raw_rows` acquired into one cell(.raw_data), so re-iterate all rows


### PR DESCRIPTION
Table now updates on entity delete.

Fixes:
- #104

I had this code in my head before the original PR, but hadn't found a use case for it yet. Guess I couldn't bear to delete my precious entities. :grin:

(I had tested it by deleting list items in an attribute and by adjusting the config to remove entities from scope, but never actually deleted an entity. Sigh...)

Code is the same as before with added row count check. If row count is different, no need to check last_updated.