### PR TITLE
feat-register-for-visual-selection

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -464,6 +464,14 @@ class FlexTableCard extends HTMLElement {
 
     setConfig(config) {
         // get & keep card-config and hass-interface
+        if (!config.entities) {
+            throw new Error('Please provide the "entities" option as a list.');
+        }
+
+        if (!config.columns) {
+            throw new Error('Please provide the "columns" option as a list.');
+        }
+
         const root = this.shadowRoot;
         if (root.lastChild)
             root.removeChild(root.lastChild);
@@ -615,3 +623,10 @@ class FlexTableCard extends HTMLElement {
 
 customElements.define('flex-table-card', FlexTableCard);
 
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: "flex-table-card",
+    name: "Flex Table Card",
+    description: "The Flex Table card gives you the ability to visualize tabular data." // optional
+});


### PR DESCRIPTION
Currently, the `custom:flex-table-card` type does not show up in the dialog launched by the `+  ADD CARD` button, even though it is installed.

This simple enhancement displays the card among the other available cards in the card selection dialog:

![VisualSelector](https://github.com/custom-cards/flex-table-card/assets/56356940/8555ee97-469b-48ff-97bd-cbb8d981c1d4)

Meaningful initial error messages are also displayed in the Card Configuration dialog. This is the current initial view when adding a new card:

![CurrentError](https://github.com/custom-cards/flex-table-card/assets/56356940/62fb9610-3d72-447b-a735-56ef93316e05)

With the added error checking, the initial view is now:

![CardConfiguration](https://github.com/custom-cards/flex-table-card/assets/56356940/5d4bf2fe-8c1d-43c4-b5a1-df8dbe2c42b0)
