### PR TITLE
fix-sort-order-for-special-chars

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -19,9 +19,9 @@ var compare = function(a, b) {
 			var b1 = b.split('.').reduce(function(ipInt, octet) { return (ipInt<<8) + parseInt(octet, 10)}, 0) >>> 0;
         return (a1 - b1);
 	}   else if (isNaN(a))
-        return a.toString().localeCompare(b);
+        return a.toString().localeCompare(b, navigator.language);
     else if (isNaN(b))
-        return -1 * b.toString().localeCompare(a);
+        return -1 * b.toString().localeCompare(a, navigator.language);
 	else
         return parseFloat(a) - parseFloat(b);
 }


### PR DESCRIPTION
I'm not an expert, but this seems to resolve #110 .

May also need `, { sensitivity: 'base' }` for other cases, but this PR correctly sorts the Danish words in the Issue when language is set to `da` in Chrome and doesn't seem to cause any issues with `en-US`.