### PR TITLE
Add support for service responses

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -658,8 +658,16 @@ class FlexTableCard extends HTMLElement {
             }).then(return_response => {
                 const entities = new Array();
                 Object.keys(return_response.response).forEach((entity_id, idx) => {
-                    const entity_key = (Object.keys(return_response.response))[idx];
-                    const resp_obj = { "entity_id": entity_id, "attributes": return_response.response[entity_key] };
+                    let resp_obj = {};
+                    if (entity_list.length > 0) {
+                        // Return payload(s) below entity key(s).
+                        const entity_key = (Object.keys(return_response.response))[idx];
+                        resp_obj = { "entity_id": entity_id, "attributes": return_response.response[entity_key] };
+                    }
+                    else {
+                        // Return entire response payload.
+                        resp_obj = { "entity_id": entity_id, "attributes": return_response.response };
+                    }
                     entities.push(resp_obj);
                 })
                 this._fill_card(entities, config, root);


### PR DESCRIPTION
As discussed in Issue #130, the core HA team intends to eliminate large entity attribute values in favor of service call return values. This PR allows `flex-table-card` to populate itself via service call responses. 

Consider this example from the `National Weather Service` `nws`, a `weather` service integration:

![ForecastView](https://github.com/custom-cards/flex-table-card/assets/56356940/a4249b3b-878c-45ea-b1f1-96de311aa322)

The config for this view is:

```
type: custom:flex-table-card
entities:
  - weather.kboi_daynight
columns:
  - name: Detailed Forecast
    data: forecast
    modify: x.detailed_description
  - name: Time Valid
    data: forecast
    modify: new Date(x.datetime).toLocaleString()
  - name: Precipitation Probability
    data: forecast
    modify: x.precipitation_probability
    suffix: '%'
  - name: Condition
    data: forecast
    modify: x.condition
  - name: Temperature
    data: forecast
    modify: x.temperature
    suffix: °
  - name: Dew Point
    data: forecast
    modify: x.dew_point
    suffix: °
  - name: Humidity
    data: forecast
    modify: x.humidity
    suffix: '%'
  - name: Wind Speed
    data: forecast
    modify: x.wind_speed
    suffix: mph
  - name: Wind Bearing
    data: forecast
    modify: x.wind_bearing
    suffix: °
```

An identical view can be achieved by loading from a service call simply by adding these lines to the config:

```
service: weather.get_forecasts
service_data:
  type: twice_daily
```

This works for a list of entities as well.

Also consider the `todo` integration. Entities do not contain task information as attributes, so the **_only_** way for flex-table-card to populate itself is via a service call.

![TodoView](https://github.com/custom-cards/flex-table-card/assets/56356940/f41efdb3-3f63-47bf-91f5-87ebcf16e6a6)

The config for this is:

```
type: custom:flex-table-card
service: todo.get_items
service_data:
  status: needs_action
entities:
  - todo.service_test
columns:
  - name: Summary
    data: items
    modify: x.summary
  - name: Needs Action
    data: items
    modify: if (x.status == "needs_action") {"Yes"} else {"No"}
```

The card will populate itself on load and whenever the listed entities are updated. This works fine for the `weather` integration, since the entity will update frequently with current conditions, causing the card to call the service and refresh itself.