### PR TITLE
Add link to service examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,6 @@ resources:
   * [Advanced Cell Formatting](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-advanced-cell-formatting.md)
   * [Formatting with CSS](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-css.md)
   * [Auto Entities](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-autoentities.md)
+  * [Loading from Services](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-services.md)
 * [Configuration Reference](https://github.com/custom-cards/flex-table-card/tree/master/docs/config-ref.md)
 * [How to Contribute](https://github.com/custom-cards/flex-table-card/tree/master/docs/contribute.md)


### PR DESCRIPTION
Link to service examples on main README page got lost in the "churn".