### PR TITLE
feat-disable-manual-sort

### DIFF
--- a/docs/config-ref.md
+++ b/docs/config-ref.md
@@ -17,6 +17,7 @@ Flex Table gives you the possibility to visualize any tabular data within Lovela
 | `title`                | string          |   optional    | A title for the card
 | `strict`               | boolean         |   optional    | If `true`, each cell must have a match, or row will be hidden [example](https://github.com/custom-cards/flex-table-card/blob/master/docs/example-cfg-sorting-strict.md)
 | `sort_by[-\|+]`        | col-id          |   optional    | Sort by given column, '+' (ascending) or '-' (descending) [example](https://github.com/custom-cards/flex-table-card/blob/master/docs/example-cfg-sorting-strict.md)
+| `disable_header_sort`  | boolean         |   optional    | Disable manual sorting by column headers (default: `false`)
 | `max_rows`             | int             |   optional    | Restrict the number of (shown) rows to this maximum number
 | `clickable`            | boolean         |   optional    | Activates the entities' on-click popup dialog
 | `css`                  | section         |   optional    | Modify the CSS-style of this flex-table instance [(css example)](https://github.com/custom-cards/flex-table-card/blob/master/docs/example-cfg-css.md)

--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -572,26 +572,29 @@ class FlexTableCard extends HTMLElement {
         // append card to _root_ node...
         root.appendChild(card);
 
-        // add sorting click handler to header elements
-        this.tbl.headers.map((obj, idx) => {
-            root.getElementById(obj.id).onclick = (click) => {
-                // remove previous sort by
-                this.tbl.headers.map((obj, idx) => {
-                    root.getElementById(obj.id).classList.remove("headerSortDown");
-                    root.getElementById(obj.id).classList.remove("headerSortUp");
-                });
-                this.tbl.updateSortBy(idx);
-                if (this.tbl.sort_by.indexOf("+") != -1) {
-                    root.getElementById(obj.id).classList.add("headerSortUp");
-                } else {
-                    root.getElementById(obj.id).classList.add("headerSortDown");
-                }
-                this._updateContent(
-                    root.getElementById("flextbl"),
-                    this.tbl.get_rows()
-                );
-            };
-        });
+        // add sorting click handler to header elements, if allowed
+        if (!config.disable_header_sort) {
+
+            this.tbl.headers.map((obj, idx) => {
+                root.getElementById(obj.id).onclick = (click) => {
+                    // remove previous sort by
+                    this.tbl.headers.map((obj, idx) => {
+                        root.getElementById(obj.id).classList.remove("headerSortDown");
+                        root.getElementById(obj.id).classList.remove("headerSortUp");
+                    });
+                    this.tbl.updateSortBy(idx);
+                    if (this.tbl.sort_by.indexOf("+") != -1) {
+                        root.getElementById(obj.id).classList.add("headerSortUp");
+                    } else {
+                        root.getElementById(obj.id).classList.add("headerSortDown");
+                    }
+                    this._updateContent(
+                        root.getElementById("flextbl"),
+                        this.tbl.get_rows()
+                    );
+                };
+            });
+        }
 
         this._config = cfg;
     }


### PR DESCRIPTION
Add ability to disable runtime sorting by clicking on column header. 

A new config item `disable_header_sort`, if set to `true`, prevents manual sorting. It is `false` by default.

Documentation has been updated.

Closes #136.