### PR TITLE
Service call target should be empty if no entity is defined

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -664,7 +664,7 @@ class FlexTableCard extends HTMLElement {
                 "domain": domain,
                 "service": service,
                 "service_data": service_data,
-                "target": { "entity_id": entity_list },
+                "target": entity_list.length ? { "entity_id": entity_list } : undefined,
                 "return_response": true,
             }).then(return_response => {
                 const entities = new Array();


### PR DESCRIPTION
Certain service call will fail if a target is defined (eg. seventeentrack.get_packages). This commit fixes the problem.