### PR TITLE
Fix data provided to compare function for sort_unmodified

### DIFF
--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -447,7 +447,7 @@ class DataRow {
                 suf: cfg.suffix || "",
                 css: cfg.align || "left",
                 hide: cfg.hidden,
-                raw_content: raw,
+                raw_content: Object.values(raw)[0],
                 sort_unmodified: cfg.sort_unmodified
             });
         });


### PR DESCRIPTION
Never mind. I covered this issue in the docs. It's unfortunate that the `modify` feature has to be used to select data from a structure, effectively rendering `sort_unmodified` unusable in those cases. Perhaps this can be remedied in the future.