### PR TITLE
Add new fields for column data option

### DIFF
--- a/docs/example-cfg-data.md
+++ b/docs/example-cfg-data.md
@@ -10,14 +10,29 @@ for the assigned value of `data`:
 * `name` = *friendliest name* will be selected
 * `object_id` = full entity *path* without domain
 * `icon` = renders the entity's current icon (`entity.attributes.icon`) into the cell
-* `device` = name of the device that the entity belongs to, if available
-* `area` = name of the area that the entity or its device is assigned to, if available
 * `_state`= is a *hack* to be able to select `entity.attributes.state` as data
 * any `key in this.entity` (e.g., `entity_id`, `state`, ...)
-* otherwise a key within `this.entity.attributes` will be assumed 
+* a matching key within `this.entity.attributes`
 
 When accessing attributes, sometimes an attribute object will itself contain objects.
 In that case, you can access the lower object using dotted notation.  eg: object1.object2.field1
+
+In addition to the above references, the following keywords are supported for entities:
+
+* `area` = name of the area that the entity or its device is assigned to, if available
+* `floor` = name of the floor that the entity's area is assigned to, if available
+* `device` = name of the device that the entity belongs to, if available
+* `device_via_device` = name of the parent device of the entity's device, if available
+* `device_hw_version` = hardware version of the device that the entity belongs to, if available
+* `device_sw_version` = software version of the device that the entity belongs to, if available
+* `device_manufacturer` = manufacturer of the device that the entity belongs to, if available
+* `device_model` = model of the device that the entity belongs to, if available
+* `device_serial_number` = serial number of the device that the entity belongs to, if available
+* `platform` = name of the domain that the entity belongs to (e.g., `sensor`, `light`, ...)
+
+If there is a conflict between an attribute name and one of these special keywords,
+the attribute name takes precedence. Note that even if a `device` or an `area` is defined for an `entity`,
+the information may not be available for `flex-table` to display.
 
 If the chosen `data` selector does not resolve to something useful, the
 cell will be marked with an error - collection/rendering should continue w/o any 
@@ -29,8 +44,6 @@ for being an `Array.isArray()`).
 **Multiple, different selectors can be used** for a single column data selection by just separating 
 each one using a comma `,`. If multiple selectors are used the resulting data is concatenated using 
 `multi_delimiter`, which defaults to a whitespace ' '.
-
-Note that even if a `device` or an `area` is defined for an `entity`, it may not be available for `flex-table` to display.
 
 ### Migration from versions < 0.7
 Since version 0.7 the old selectors (`attr`, `prop`, `attr_as_list`, `multi`) are all replaced by

--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -287,12 +287,6 @@ class DataRow {
                         // 'icon' will show the entity's default icon
                         let _icon = this.entity.attributes.icon;
                         raw_content.push(`<ha-icon id="icon" icon="${_icon}"></ha-icon>`);
-                    } else if (col_key === "area") {
-                        // 'area' will show the entity's or its device's assigned area, if any
-                        raw_content.push(this._get_area_name(this.entity.entity_id, hass));
-                    } else if (col_key === "device") {
-                        // 'device' will show the entity's device name, if any
-                        raw_content.push(this._get_device_name(this.entity.entity_id, hass));
                     } else if (col_key === "state" && config.auto_format && !col.no_auto_format) {
                         // format entity state
                         raw_content.push(hass.formatEntityState(this.entity));
@@ -307,6 +301,36 @@ class DataRow {
                         else {
                             raw_content.push(this.entity.attributes[col_key]);
                         }
+                    } else if (col_key === "area") {
+                        // 'area' will show the entity's or its device's assigned area, if any
+                        raw_content.push(this._get_area_name(this.entity.entity_id, hass));
+                    } else if (col_key === "floor") {
+                        // 'floor' will show the entity's area's floor, if any
+                        raw_content.push(this._get_floor_name(this.entity.entity_id, hass));
+                    } else if (col_key === "device") {
+                        // 'device' will show the entity's device name, if any
+                        raw_content.push(this._get_device_name(this.entity.entity_id, hass));
+                    } else if (col_key === "device_hw_version") {
+                        // 'device_hw_version' will show the entity's device hardware version, if any
+                        raw_content.push(this._get_device_value(this.entity.entity_id, hass, "hw_version"));
+                    } else if (col_key === "device_manufacturer") {
+                        // 'device_manufacturer' will show the entity's device manufacturer, if any
+                        raw_content.push(this._get_device_value(this.entity.entity_id, hass, "manufacturer"));
+                    } else if (col_key === "device_model") {
+                        // 'device_model' will show the entity's device model, if any
+                        raw_content.push(this._get_device_value(this.entity.entity_id, hass, "model"));
+                    } else if (col_key === "device_serial_number") {
+                        // 'device_serial_number' will show the entity's device serial number, if any
+                        raw_content.push(this._get_device_value(this.entity.entity_id, hass, "serial_number"));
+                    } else if (col_key === "device_sw_version") {
+                        // 'device_sw_version' will show the entity's device software version, if any
+                        raw_content.push(this._get_device_value(this.entity.entity_id, hass, "sw_version"));
+                    } else if (col_key === "device_via_device") {
+                        // 'device_via_device' will show the entity's device via name, if any
+                        raw_content.push(this._get_device_via(this.entity.entity_id, hass));
+                    } else if (col_key === "platform") {
+                        // 'platform' will show the entity's platform (domain), if any
+                        raw_content.push(this._get_platform(this.entity.entity_id, hass));
                     } else {
                         // no matching data found, complain:
                         //raw_content.push("[[ no match ]]");
@@ -413,22 +437,62 @@ class DataRow {
 
     _get_device_name(entity_id, hass) {
         var device_id;
-        if (hass.entities[entity_id] !== undefined) {
+        if (hass.entities[entity_id] != null) {
             device_id = hass.entities[entity_id].device_id;
         }
-        return device_id === undefined ? "-" : hass.devices[device_id].name_by_user || hass.devices[device_id].name;
+        return device_id == null ? "-" : hass.devices[device_id].name_by_user || hass.devices[device_id].name;
+    }
+
+    _get_device_via(entity_id, hass) {
+        var device_id;
+        var via_device_id;
+        if (hass.entities[entity_id] != null) {
+            device_id = hass.entities[entity_id].device_id;
+        }
+        if (device_id != null) {
+            via_device_id = hass.devices[device_id].via_device_id
+        }
+        return via_device_id == null ? "-" : hass.devices[via_device_id].name_by_user || hass.devices[via_device_id].name;
+    }
+
+    _get_device_value(entity_id, hass, parameter) {
+        var device_id;
+        if (hass.entities[entity_id] != null) {
+            device_id = hass.entities[entity_id].device_id;
+        }
+        return device_id == null || hass.devices[device_id][parameter] == null ? "-" :
+            hass.devices[device_id][parameter];
     }
 
     _get_area_name(entity_id, hass) {
         var area_id;
-        if (hass.entities[entity_id] !== undefined) {
+        if (hass.entities[entity_id] != null) {
             area_id = hass.entities[entity_id].area_id;
-            if (area_id === undefined) {
+            if (area_id == null) {
                 let device_id = hass.entities[entity_id].device_id;
-                if (device_id !== undefined) area_id = hass.devices[device_id].area_id;
+                if (device_id != null) area_id = hass.devices[device_id].area_id;
             }
         }
-        return area_id === undefined || hass.areas[area_id] === undefined ? "-" : hass.areas[area_id].name;
+        return area_id == null || hass.areas[area_id] == null ? "-" : hass.areas[area_id].name;
+    }
+
+    _get_floor_name(entity_id, hass) {
+        var area_id;
+        var floor_id;
+        if (hass.entities[entity_id] != null) {
+            area_id = hass.entities[entity_id].area_id;
+            if (area_id == null) {
+                let device_id = hass.entities[entity_id].device_id;
+                if (device_id != null) area_id = hass.devices[device_id].area_id;
+            }
+            if (area_id != null) floor_id = hass.areas[area_id].floor_id;
+        }
+        return floor_id == null || hass.floors[floor_id] == null ? "-" : hass.floors[floor_id].name;
+    }
+
+    _get_platform(entity_id, hass) {
+        var entity = hass.entities[entity_id]
+        return entity == null || entity.platform == null ? "-" : entity.platform;
     }
 
     render_data(col_cfgs) {


### PR DESCRIPTION
This PR is to add some data fields that are related to the displayed entity. The new fields are:

* `floor` = name of the floor that the entity's area is assigned to, if available
* `platform` = name of the domain that the entity belongs to (e.g., `sensor`, `light`, ...)
* `device_via_device` = name of the parent device of the entity's device, if available
* `device_hw_version` = hardware version of the device that the entity belongs to, if available
* `device_sw_version` = software version of the device that the entity belongs to, if available
* `device_manufacturer` = manufacturer of the device that the entity belongs to, if available
* `device_model` = model of the device that the entity belongs to, if available
* `device_serial_number` = serial number of the device that the entity belongs to, if available

While this does not close any issues, it satisfies several open topics in the [Flex-Table-Card community discussion](https://community.home-assistant.io/t/flex-table-card/461173), #355 and #357. It is essentially a natural extension of the `device` and `area` features already available.

Note that if there is a conflict between an attribute name and one of these new names, the attribute name takes precedence.

Would this be a good time for a dot release? Otherwise the documentation will be ahead of the current one.