### PR TITLE
Docs update: explain auto-refresh when using Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ resources:
   * [Advanced Cell Formatting](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-advanced-cell-formatting.md)
   * [Formatting with CSS](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-css.md)
   * [Auto Entities](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-autoentities.md)
-  * [Loading from Services](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-services.md)
+  * [Loading from Actions and Scripts](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-services.md)
   * [Loading from Files](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-files.md)
   * [Editing and Calling Actions](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-calling-actions.md)
   * [Adding a Summary Footer](https://github.com/custom-cards/flex-table-card/tree/master/docs/example-cfg-footers.md)

--- a/docs/config-ref.md
+++ b/docs/config-ref.md
@@ -29,7 +29,7 @@ Flex Table gives you the possibility to visualize any tabular data within Lovela
 | `- ...`                | item(s)         |   optional    | 
 | `entities`             | section         | **required**  | Section defining the entities, either as the *data sources* or for use by an action (see below). If no entities are required for an action, use [] and omit `include/exclude`
 | `- ...`                | item(s)         | **required**  | 
-| `action`               | string          |   optional    | Action to act as *data source* instead of entities. Use `entities` to define entities for the action.<a href="#fn2"><sup>[2]</sup></a>
+| `action`               | string          |   optional    | Action to act as *data source* instead of entities. Use `entities` to define entities for the action.<a href="#fn2"><sup>[2]</sup></a> See [Examples - Loading from Actions and Scripts](example-cfg-services.md#examples---loading-from-actions-and-scripts)
 | `action_data`          | section         |   optional    | Section defining `data` required by the action, if any (see below)
 | `- ...`                | item(s)         |   optional    | 
 | `columns`              | section         | **required**  | Section defining the column(s) and its contents (see below)

--- a/docs/example-cfg-services.md
+++ b/docs/example-cfg-services.md
@@ -1,4 +1,4 @@
-# Examples - Actions
+# Examples - Loading from Actions and Scripts
 
 ## Convert from attributes to action
 <!-- [full text section] -->
@@ -179,5 +179,131 @@ select_element:
 <img src="../images/Outback.png" alt="Select array element example result" width="500px">
 
 This technique can be used multiple times in the same `data` statement if there are multiple arrays in the path.
+
+### Refreshing table contents populated by Actions
+
+Home Assistant does not automatically know when the response of an action might change.
+Therefore, it is not possible to have a `flex-table-card` automatically refresh when this happens.
+However, if an entity is specified in the card definition, the card will refresh whenever the state
+or attributes of the entity changes, and that may be a good solution.
+
+Consider this example to display the hourly weather forecast from the National Weather Service in Boise, Idaho:
+
+``` yaml
+type: custom:flex-table-card
+title: Weather Forecast Example
+action: weather.get_forecasts
+action_data:
+  type: hourly
+entities:
+  - weather.kboi_daynight
+columns:
+  - name: Time Valid
+    data: forecast.datetime
+    modify: new Date(x).toLocaleString()
+  - name: Temperature
+    data: forecast.temperature
+    suffix: °
+  - name: Precipitation
+    data: forecast.precipitation_probability
+    suffix: "%"
+  - name: Wind Speed
+    data: forecast.wind_speed
+    modify: x.toFixed(0)
+    suffix: " mph"
+```
+
+The `weather.get_forecasts` Action requires an entity, in this case `weather.kboi_daynight`. Whenever the
+state or attributes of this entity (which tracks current conditions, not the forecast) changes, the table
+will automatically update the forecast.
+
+### Refreshing table contents populated by custom Scripts
+
+Tables populated by scripts can be automatically updated as well by including entities in the card definition.
+However, a change to the script is required to make this work properly.
+
+When an Action that returns a response is called, it usually requires that an entity be specified. In the
+response, the first level of JSON returned will be that entity. Consider this call to return the contents of
+two `todo` lists, which can be run in the `Actions` tab of `Developer tools` with your own `todo` entities:
+
+``` yaml
+action: todo.get_items
+target:
+  entity_id:
+    - todo.first_list
+    - todo.second_list
+```
+
+The returned response data is structured like this (some values removed for brevity):
+
+``` yaml
+todo.first_list:
+  items:
+    - summary: First task
+      description: First task on first list
+    - summary: Second task
+      description: Second task on first list
+todo.second_list:
+  items:
+    - summary: First task
+      description: First task on second list
+    - summary: Second task
+      description: Second task on second list
+```
+
+Notice the top level keys, the entities to which the data belongs.
+
+**When using a custom script to return data to a `flex-table-card`:
+* If one or more entities are specified in the definition, the top level of the returned
+JSON for each entity MUST be the entity_id.
+* If entities are NOT specified (`entities: []`), the top level
+MUST be the key of the list of rows, such as `items` in the above example.**
+
+The entity returned in the response does not need to be the same as the one(s) in the card definition. In fact,
+it doesn't even have to be a valid entity...what is important is its position in the JSON. However, this
+string will be used as the entity_id for any operations on the row, such as when `clickable: true` is set
+to show the `more-info` dialog, so it makes sense to return the correct entity_id.
+
+Here is a contrived example that shows how you can even specify the entity for the script to use in the
+card definition:
+
+``` yaml
+type: custom:flex-table-card
+clickable: true
+action: script.test_script_refresh
+entities:
+  - light.office_overheads
+columns:
+  - name: Light
+    data: records.friendly_name
+  - name: State
+    data: records.state
+```
+
+The script would then be:
+
+``` yaml
+test_script_refresh:
+  variables:
+    values: >
+      {% set response = { entity_id[0] : { "records" : [
+        {
+          "friendly_name" : state_attr(entity_id[0],"friendly_name"),
+          "state" : states(entity_id[0])
+        }
+      ] } }
+      %}
+      {{ response }}
+  sequence:
+    - stop: All Done
+      response_variable: values
+```
+
+This script supports the use of entities in the card definition by supplying an additional level to the
+JSON hierarchy, with `entity_id[0]` as the key to this new top level. (`entity_id` returns an array of
+entities specified in the card. However, this simple example only works for a single entity.)
+
+When the state of the light entity changes, the script is refreshed. Clicking on the row invokes the
+more-info dialog, or could call an action using the entity.
 
 [Return to main README.md](../README.md)

--- a/docs/example-cfg-services.md
+++ b/docs/example-cfg-services.md
@@ -253,11 +253,11 @@ todo.second_list:
 
 Notice the top level keys, the entities to which the data belongs.
 
-When using a custom script to return data to a `flex-table-card`:
+**IMPORTANT:** When using a custom script to return data to a `flex-table-card`:
 * If one or more entities are specified in the definition, the top level key of the returned
 JSON for each entity MUST be the entity_id.
 * If entities are NOT specified (`entities: []`), the top level MUST be the key of the list of rows,
-such as `items` in the above example (`items` would only occur once).
+such as `items` in the above example (`items` would only occur once in this case).
 
 The entity returned in the response does not need to be the same as the one(s) in the card definition. In fact,
 it doesn't even have to be a valid entity...what is important is its position in the JSON. However, this

--- a/docs/example-cfg-services.md
+++ b/docs/example-cfg-services.md
@@ -253,11 +253,11 @@ todo.second_list:
 
 Notice the top level keys, the entities to which the data belongs.
 
-**When using a custom script to return data to a `flex-table-card`:
-* If one or more entities are specified in the definition, the top level of the returned
+When using a custom script to return data to a `flex-table-card`:
+* If one or more entities are specified in the definition, the top level key of the returned
 JSON for each entity MUST be the entity_id.
-* If entities are NOT specified (`entities: []`), the top level
-MUST be the key of the list of rows, such as `items` in the above example.**
+* If entities are NOT specified (`entities: []`), the top level MUST be the key of the list of rows,
+such as `items` in the above example (`items` would only occur once).
 
 The entity returned in the response does not need to be the same as the one(s) in the card definition. In fact,
 it doesn't even have to be a valid entity...what is important is its position in the JSON. However, this
@@ -304,6 +304,6 @@ JSON hierarchy, with `entity_id[0]` as the key to this new top level. (`entity_i
 entities specified in the card. However, this simple example only works for a single entity.)
 
 When the state of the light entity changes, the script is refreshed. Clicking on the row invokes the
-more-info dialog, or could call an action using the entity.
+more-info dialog for the entity, or you could use tap-actions to call an action using the entity.
 
 [Return to main README.md](../README.md)


### PR DESCRIPTION
This docs-only PR explains the way auto-refresh can work for Actions and Scripts by using entities in the definition.

Closes #163.

A release is not necessary...up to you. I'll mention it in the community page once it's merged.