### PR TITLE
Feat: Add icon formatter for displaying HA icons in cells

### DIFF
--- a/docs/config-ref.md
+++ b/docs/config-ref.md
@@ -122,6 +122,7 @@ Apart from that `modify` and `footer_modify` are very powerful, see [advanced ce
 * `number`
 * `duration`
 * `duration_h`
+* `icon`
 
 Feel free to contribute formatters. Just share your best `modify` line to allow others to use them, too.
 

--- a/flex-table-card.js
+++ b/flex-table-card.js
@@ -90,6 +90,9 @@ class CellFormatters {
         if (m) s = s.padStart(2, 0);
         return d + h + m + s;
     }
+    icon(data) {
+        return `<ha-icon icon="${data}"></ha-icon>`;
+    }
 
 
 }


### PR DESCRIPTION
## Add icon formatter for displaying Home Assistant icons

  ### Description
  This PR adds a new `icon` formatter to the available formatters in flex-table-card. This formatter allows users to display Home Assistant icons in table cells by converting icon names (e.g., `mdi:home`) into proper `<ha-icon>` elements.

  ### Changes
  - Added `icon` formatter to the `CellFormatters` class in `flex-table-card.js`
  - Updated documentation in `docs/config-ref.md` to include the new formatter

  ### Usage
  Users can now use the `icon` formatter in their column configuration:

```yaml
columns:
  - name: Status
    data: icon_name
    fmt: icon
```

Where `icon_name` contains a value as a valid Home Assistant icon identifier like `mdi:thermometer`, `mdi:lightbulb`, etc.