### PR TITLE
Docs: Explain use of sort_unmodified in footer summary operations

### DIFF
--- a/docs/config-ref.md
+++ b/docs/config-ref.md
@@ -102,7 +102,7 @@ definition. Apart from `sort_by` no other option requires referencing of this id
 | `no_auto_format`       | boolean  |   optional    | Disable auto formatting for this column when auto_format: true (default: `false`)
 | `multi_delimiter`      | string   |   optional    | defaults to ' ', concat multiple selector-data using this string
 | `fmt`                  | string   |   optional    | format using predefined 'formatters'<a href="#fn4"><sup>[4]</sup></a>
-| `sort_unmodified`      | boolean  |   optional    | Sort using original value before `modify` option, if any, is applied (default: `false`)
+| `sort_unmodified`      | boolean  |   optional    | Sort using original value before `modify` option, if any, is applied (default: `false`). Also affects footer row operations `sum`, `average`, `max`, and `min`.
 | `footer_type`          | string   |   optional    | Used with `display_footer`, one of `sum`, `average`, `count`, `max`, `min`, or `text`
 | `footer_text`          | string   |   optional    | Used with `display_footer`, text to be dispayed in this and optionally across several more columns (see `footer_colspan`)
 | `footer_colspan`       | string   |   optional    | Used with `display_footer` and `footer_text`, displays text across specified number of columns

--- a/docs/example-cfg-footers.md
+++ b/docs/example-cfg-footers.md
@@ -32,6 +32,12 @@ Only cells with values that can be interpreted as numbers will be included in th
 The number can have leading and trailing spaces, and any number of trailing non-numeric characters, but only the column `prefix` plus _one_ leading non-numeric character, 
 such as a currency sign. Otherwise it will be ignored.
 
+### Raw vs. modified values
+
+By default, the summary calculations are performed on the modified data values retrieved for the column, after any `modify` function is applied.
+To use the raw data values instead, set `sort_unmodified: true` for the column. This can be useful when the `modify` function produces non-numeric 
+values for display, such as time values with colons as separators.
+
 ### Formatting values
 
 The formatting options `align`, `prefix`, and `suffix` (but not `modify`) will also apply to the summary row.


### PR DESCRIPTION
Update docs to explain how the `sort_unmodified` column setting can be used to force footer summary operations to use raw values instead of modified values.

Closes #191.